### PR TITLE
feat: add on_confirm listener when publish msg to exchange/queue

### DIFF
--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -72,9 +72,14 @@ module LogStash
       def publish(event, message)
         raise ArgumentError, "No exchange set in HareInfo!!!" unless @hare_info.exchange
         routing_key = event.sprintf(@key)
+        connect_retry_interval = event.sprintf(@connect_retry_interval * 1000).to_i
         message_properties = @message_properties_template.build(event)
         @gated_executor.execute do
           local_exchange.publish(message, :routing_key => routing_key, :properties => message_properties)
+          local_got_ack = local_channel.wait_for_confirms(connect_retry_interval)
+          if !local_got_ack
+            raise MarchHare::Exception.new('Got an nack message')
+          end
         end
       rescue MarchHare::Exception, IOError, AlreadyClosedException, TimeoutException => e
         @logger.error("Error while publishing, will retry", error_details(e, backtrace: true))
@@ -96,6 +101,7 @@ module LogStash
         channel = @thread_local_channel.get
         if !channel
           channel = @hare_info.connection.create_channel
+          channel.confirm_select
           @thread_local_channel.set(channel)
         end
         channel


### PR DESCRIPTION
<!--
Please first search existing issues for the feature you are requesting;
it may already exist, even as a closed issue.
-->

<!--
Describe the feature.

Please give us as much context as possible about the feature. For example,
you could include a story about a time when you wanted to use the feature,
and also tell us what you had to do instead. The last part is helpful
because it gives us an idea of how much harder your life is without the
feature.

-->
After setting `max-length` or `max-length-bytes` policy to the rabbitmq server, the output plugin does not seem to process the ack signal.

I found a relative question in the [forum](https://discuss.elastic.co/t/output-to-rabbitmq-does-not-honor-reject-publish/310565)